### PR TITLE
docs: reboot-align public docs + real root CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 docs/wolfram/
 .worktrees
 .claude
+/CLAUDE.local.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ rebooted catgraph's core + physics layer.
 
 ### Changed
 
+- **Docs reboot-aligned**: root `CLAUDE.md` is now a real public file
+  (purpose, build/test, feature matrix, durable rules) instead of a
+  private include; `README.md` reflects the sustia-llc/catgraph v0.2.0
+  dep, the example-consumer role, current test counts, and the persist
+  removal. Work tracking moved to GitHub issues (`TODO.md` retired
+  with pointers).
+
 - **catgraph dependencies repointed** from the retired
   `tsondru/catgraph` lineage (`v0.13.0`) to the rebooted
   `sustia-llc/catgraph` (`v0.2.0`, SSH; single tag string shared by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,65 @@
-@.claude/CLAUDE.md
+# irreducible
+
+Computational irreducibility as functoriality in Rust — Jonathan Gorard,
+*A Functorial Perspective on (Multi)computational Irreducibility*
+(arXiv:2301.04690). A computation is irreducible iff the functor
+Z′: T → B (computations → cobordism intervals) preserves composition.
+
+Example consumer of the [catgraph](https://github.com/sustia-llc/catgraph)
+core + physics layer. Machine zoo: Turing machines, elementary CA, string
+rewriting, nondeterministic TMs, hypergraph DPO rewriting, Petri nets.
+
+## Build & test
+
+```sh
+cargo build --workspace
+cargo test  --workspace                                      # every change: green before merge
+cargo test  --workspace --features manifold-curvature,dec    # feature leg (CI-gated)
+cargo clippy --workspace --all-targets -- -D warnings        # the CI gate
+cargo clippy --workspace --all-targets -- -W clippy::pedantic  # advisory local pass
+cargo fmt   --all --check
+cargo run --example gorard_demo                              # 9-part paper walkthrough
+```
+
+Rust 2024 edition, MSRV 1.90.
+
+## Dependencies
+
+- `catgraph` / `catgraph-applied` / `catgraph-physics` — git tag on the
+  private `sustia-llc/catgraph` workspace (SSH). **ONE tag string shared by
+  all three** (dual-SHA prevention; see the Cargo.toml comments).
+- `deep_causality_{topology,tensor,sparse}` — currently git-rev-pinned
+  pre-release (one shared rev string); swap to crates.io pins once released.
+- CI authenticates the private catgraph dep with a read-only deploy key +
+  `webfactory/ssh-agent`; `Cargo.lock` is committed and CI builds `--locked`.
+
+## Feature flags
+
+| Feature | Gates |
+|---------|-------|
+| *(none)* | Core library — purely computational, no I/O, no async |
+| `dc-geometry` | deep_causality_topology Regge + DEC substrate |
+| `manifold-curvature` | Regge deficit-angle curvature on branchial complexes |
+| `dec` | Discrete exterior calculus on multiway complexes |
+| `lapack` | LAPACK eigendecomposition (needs `libopenblas-dev`; not in CI) |
+
+`persist` (SurrealDB evolution-trace storage) was **removed** pending the
+catgraph-surreal reboot — pre-reboot catgraph-surreal pins the retired
+catgraph lineage (type-identity mismatch). Restore path: issue #15.
+
+## Rules
+
+1. **The paper is the spec.** Gorard 2023 anchors the API; the mapping lives
+   in `docs/GORARD23-AUDIT.md`.
+2. **Every change is green** — `cargo test` + clippy `-D warnings` + fmt
+   before merge; work lands via branch + PR on CI.
+3. **Never a path dep in committed state.** The commented `[patch]` block is
+   for local lock-step only; all deps sharing a git URL move on one
+   tag/rev string.
+4. **No `.unwrap()` in production code** — `?` → thiserror, or
+   `.expect("invariant: WHY")`; `.unwrap()` only in `#[cfg(test)]` and doc
+   examples.
+5. **Upstream gaps are upstream issues.** If a catgraph surface is missing or
+   wrong, file it on catgraph — never work around it downstream.
+
+Work is tracked as GitHub issues; TODO.md is retired.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Computational irreducibility as functoriality in Rust, implementing Jonathan Gor
 
 **Core insight**: A computation is irreducible iff a certain functor Z': T -> B (from computations to cobordisms) preserves composition. No shortcuts exist when Z' is functorial.
 
-Uses [catgraph](https://github.com/tsondru/catgraph) v0.13.0 (slim F&S baseline) for the Fong-Spivak categorical infrastructure (cospans, spans, hypergraph categories, cospan-algebras, Thm 1.2 equivalence) and [catgraph-physics](https://github.com/tsondru/catgraph) v0.13.0 for hypergraph DPO rewriting, multiway evolution graphs, confluence diamond detection, and branchial spectral analysis. irreducible owns the computation-facing layer -- interval algebra, adjunctions, monoidal coherence, discrete exterior calculus, trace analysis -- plus the computation models (TM, CA, SRS, NTM, Petri nets).
+irreducible is the **example consumer of the [catgraph](https://github.com/sustia-llc/catgraph) core + physics layer** (v0.2.0): [catgraph](https://github.com/sustia-llc/catgraph) supplies the Fong-Spivak categorical infrastructure (cospans, spans, hypergraph categories, cospan-algebras), catgraph-applied the Petri-net substrate, and catgraph-physics the hypergraph DPO rewriting, multiway evolution graphs, confluence diamond detection, and branchial spectral analysis. irreducible owns the computation-facing layer -- interval algebra, adjunctions, monoidal coherence, discrete exterior calculus, trace analysis -- plus the computation models (TM, CA, SRS, NTM, Petri nets).
 
-385 tests (+ 14 with `dec`, + 14 with `manifold-curvature`, + 14 with `dc-geometry`), zero clippy warnings. Rust 2024 edition, MSRV 1.90.
+354 tests on default features (381 with `manifold-curvature,dec`), zero clippy warnings. Rust 2024 edition, MSRV 1.90.
 
 ## Component Index
 
@@ -35,12 +35,11 @@ Uses [catgraph](https://github.com/tsondru/catgraph) v0.13.0 (slim F&S baseline)
 | `machines/multiway/manifold_bridge.rs` | `ManifoldCurvature`, `BranchialEmbedding` | Regge deficit-angle curvature on branchial complexes via dc_topology (feature-gated) |
 | `machines/petri/` | `PetriNetMachine`, `PetriBuilder`, `PetriExecutionHistory`, `run_multiway_reachability` | Place/transition Petri nets — linear trace, multiway reachability, cospan bridge |
 | `machines/hypergraph/catgraph_bridge.rs` | `MultiwayCospanExt`, `MultiwayCospanGraph` | Hypergraph evolution cospan analysis |
-| `machines/hypergraph/persistence.rs` | `EvolutionPersistence` | SurrealDB persistence (feature-gated) |
 | `types.rs` | `ComputationDomain`, `ComputationContext`, `CausalEffect` | Domain types for computation models |
 
 ## Fong-Spivak Feature Map
 
-Re-exports from catgraph v0.13.0 implementing [Fong & Spivak, *Hypergraph Categories*](https://arxiv.org/abs/1806.08304) SS2-3:
+Re-exports from catgraph v0.2.0 implementing [Fong & Spivak, *Hypergraph Categories*](https://arxiv.org/abs/1806.08304) SS2-3:
 
 | Paper Reference | Re-exported Type | Purpose |
 |-----------------|------------------|---------|
@@ -122,7 +121,8 @@ assert!(functorial && stokes_ok && frobenius_ok); // all agree
 | `dec` | Discrete exterior calculus on multiway complexes | `dc-geometry`, `nalgebra` |
 | `manifold-curvature` | Regge deficit-angle curvature on branchial complexes | `dc-geometry`, `nalgebra` |
 | `lapack` | LAPACK-accelerated eigendecomposition for MDS | `nalgebra-lapack` (implies `manifold-curvature`; requires `libopenblas-dev`) |
-| `persist` | SurrealDB persistence for evolution traces | `catgraph-surreal`, `surrealdb`, `tokio` |
+
+> The former `persist` feature (SurrealDB evolution-trace storage) was removed pending the catgraph-surreal reboot; see issue [#15](https://github.com/tsondru/irreducible/issues/15) for the restore path.
 
 ## Examples
 
@@ -134,35 +134,24 @@ cargo run --example fong_spivak           # Fong-Spivak three-perspective agreem
 cargo run --example lattice_gauge         # Wilson loops, plaquette action
 cargo run --example multiway_coherence    # Non-confluent fragment failing coherence
 cargo run --example multiway_stokes --features dec  # Closed vs non-closed 1-forms
-cargo run --example persist_evolution --features persist  # SurrealDB persistence
 ```
 
 ## Testing
 
 ```bash
-cargo test --workspace                              # 385 tests, 0 ignored
-cargo test --features dc-geometry                   # +14 dc_topology smoke tests
-cargo test --features manifold-curvature            # +14 Regge curvature tests
-cargo test --features dec                           # +14 DEC tests
-cargo test --features persist                       # +15 persistence tests
-cargo test --features "dec manifold-curvature persist"  # 427 total
-cargo clippy --workspace -- -W clippy::pedantic     # zero warnings
+cargo test --workspace                               # 354 tests (default features)
+cargo test --workspace --features manifold-curvature,dec  # 381 tests (CI feature leg)
+cargo test --features dc-geometry                    # dc_topology smoke + bridge tests
+cargo clippy --workspace --all-targets -- -D warnings  # CI gate
+cargo clippy --workspace -- -W clippy::pedantic      # advisory, zero warnings
 ```
 
-| Suite | Tests | What it covers |
-|-------|-------|---------------|
-| Unit tests | ~190 | Functor, machines (TM, CA, SRS, NTM, trace), categories, types, multiway coherence |
-| `adjunction_laws` | 11 | Z' ⊣ Z triangle identities, unit/counit naturality |
-| `catgraph_bridge` | 10 | Multiway cospan analysis, composability |
-| `computation_types` | 30 | TM, CA, string rewrite, NTM classification |
-| `fong_spivak` | 11 | Re-export validation, Frobenius verification, three-way agreement |
-| `functoriality` | 16 | Functor laws, irreducibility detection |
-| `hypergraph_rewriting` | 21 | DPO matching, evolution, Wilson loops, gauge |
-| `multiway_coherence` | 10 | Associator, braiding, unitor on real multiway graphs + monoidal functor |
-| `multiway_evolution` | 16 | Branchial graphs, curvature foliation, NTM |
-| `multiway_stokes` | 8 | DEC: closed forms, d^2=0, diamond detection (feature: dec) |
-| `temporal_cospan_chain` | 11 | Cospan chain composability, conservation |
-| Doc tests | 9 | Public API examples |
+Integration suites cover: adjunction laws (Z' ⊣ Z triangle identities), the
+catgraph cospan bridge, computation-model classification (TM, CA, SRS, NTM,
+Petri), Fong-Spivak Frobenius verification, functor laws, hypergraph DPO
+rewriting + Wilson loops, multiway coherence (associator/braiding), branchial
+evolution + curvature foliation, DEC closed forms (`dec`), and temporal
+cospan-chain conservation.
 
 ## Key Concepts
 
@@ -201,10 +190,9 @@ For 1D simplicial complexes, Stokes conservation reduces to contiguity + monoton
 
 ## Dependencies
 
-- [catgraph](https://github.com/tsondru/catgraph) v0.13.0 -- category theory infrastructure (cospans, spans, Fong-Spivak hypergraph categories) — slim baseline
-- [catgraph-physics](https://github.com/tsondru/catgraph) v0.13.0 -- hypergraph DPO rewriting, multiway evolution, confluence diamonds, discrete curvature, branchial spectral analysis
+- [catgraph](https://github.com/sustia-llc/catgraph) v0.2.0 -- category theory infrastructure (cospans, spans, Fong-Spivak hypergraph categories); workspace tag shared with catgraph-applied (Petri nets) and catgraph-physics (hypergraph DPO rewriting, multiway evolution, confluence diamonds, discrete curvature, branchial spectral analysis)
 - `serde` + `serde_json` -- serialization
-- Optional: `deep_causality_topology` + `deep_causality_tensor` + `deep_causality_sparse` (Regge curvature + DEC substrate), `nalgebra` (matrix ops), `nalgebra-lapack` (LAPACK), `catgraph-surreal` + `surrealdb` + `tokio` (persistence)
+- Optional: `deep_causality_topology` + `deep_causality_tensor` + `deep_causality_sparse` (Regge curvature + DEC substrate; currently git-rev-pinned pre-release), `nalgebra` (matrix ops), `nalgebra-lapack` (LAPACK)
 
 ## References
 

--- a/docs/GORARD23-AUDIT.md
+++ b/docs/GORARD23-AUDIT.md
@@ -1,7 +1,7 @@
 # Gorard 2023 Coverage Audit (irreducible v0.6.3)
 
 > **Paper:** Jonathan Gorard, *A Functorial Perspective on (Multi)computational Irreducibility* ([arXiv:2301.04690v1](https://arxiv.org/abs/2301.04690), 13 Oct 2022, dated Jan 2023; in-tree at `docs/2301.04690v1.pdf`).
-> **Library:** `irreducible` v0.6.5+ (audit doc landed in v0.6.4 at SHA `6b3d656`; tracking maintained as the crate evolves) — workspace umbrella `catgraph` v0.13.0 / SHA `4f8bda8`.
+> **Library:** `irreducible` v0.6.5+ (audit doc landed in v0.6.4 at SHA `6b3d656`; tracking maintained as the crate evolves) — catgraph workspace tag `v0.2.0` ([sustia-llc/catgraph](https://github.com/sustia-llc/catgraph) reboot lineage; the audit's item mapping predates the reboot and is unaffected — the consumer surface carried over intact).
 > **Method:** read all 60 pages of the paper end-to-end (intro + §2 + §3 + §4 + §5 + references); cross-walked every numbered equation, definition, theorem, figure caption, and named concept against the irreducible source tree (`src/**`, `tests/**`, `examples/**`). Coverage attribution honours the v0.6.3 shim: implementations that physically live in `catgraph_physics::{interval,temporal_cospan_chain,trace}` are attributed to the irreducible surface (consumers see them as `irreducible::*`).
 > **Update cadence:** maintained alongside the crate version. Add a row whenever a new paper item is implemented; flip status (e.g. ⏭️ → ✅) when an action item closes.
 >
@@ -12,7 +12,7 @@
 > - ➖ N/A — discussion / motivational / explicitly stated as future work in the paper itself.
 > - 🔗 IN-CATGRAPH — implementation lives in catgraph / catgraph-physics / catgraph-applied; consumed via re-export.
 >
-> **Companion audits (catgraph workspace):** [`FS19-AUDIT.md`](https://github.com/tsondru/catgraph/blob/main/catgraph/docs/FS19-AUDIT.md) (catgraph), [`FS18-AUDIT.md`](https://github.com/tsondru/catgraph/blob/main/catgraph-applied/docs/FS18-AUDIT.md) (catgraph-applied), [`BV25-AUDIT.md`](https://github.com/tsondru/catgraph/blob/main/catgraph-magnitude/docs/BV25-AUDIT.md) (catgraph-magnitude).
+> **Companion audits (catgraph workspace):** [`FS19-AUDIT.md`](https://github.com/sustia-llc/catgraph/blob/main/catgraph/docs/FS19-AUDIT.md) (catgraph), [`FS18-AUDIT.md`](https://github.com/sustia-llc/catgraph/blob/main/catgraph-applied/docs/FS18-AUDIT.md) (catgraph-applied), [`BV25-AUDIT.md`](https://github.com/sustia-llc/catgraph/blob/main/catgraph-magnitude/docs/BV25-AUDIT.md) (catgraph-magnitude).
 
 ---
 


### PR DESCRIPTION
## Reboot alignment — Phase C (docs + Claude-context parity)

Brings irreducible's docs and Claude-context wiring to the catgraph reboot model.

### In this PR (repo side)
- **Root `CLAUDE.md` is now a real public file** — crate purpose, Gorard anchor, build/test commands, feature matrix (incl. the persist-removal note), reboot dep pins, and the few durable rules. Replaces the `@.claude/CLAUDE.md` include of a fully-private 30.5 KB file.
- **README reboot-aligned** — sustia-llc/catgraph v0.2.0, example-consumer role statement, current test counts (354 default / 381 `manifold-curvature,dec`), persist removal noted with the restore-path issue (#15), drift-prone per-suite test table replaced with prose.
- **GORARD23-AUDIT** — catgraph pin + companion-audit links repointed to the reboot workspace (the item mapping predates the reboot and is unaffected; the consumer surface carried over intact).
- **`.gitignore`** — `/CLAUDE.local.md`.

### Outside this PR (local/notes side, already done)
- Private strategy/history triaged into `CLAUDE.local.md` (symlink into the notes tree; dead pin blocks + pre-reboot release ceremony dropped, gotchas kept).
- Notes tree gained `memory/` (auto-memory migrated + `autoMemoryDirectory` set, mirroring catgraph) and `rules/` with a `.claude/rules` symlink; stale `settings.local.json` permissions pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)