### PR TITLE
fix: apply alignment review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: ci
-on: [push, pull_request]
+# push is filtered to main so PR-branch commits run once (pull_request event
+# only); superseded runs on the same ref are cancelled.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Private git-dep auth (first use of this pattern; copy for other consumers of
 # private catgraph):
@@ -37,3 +46,7 @@ jobs:
       # `lapack` is excluded: needs libopenblas-dev and adds no logic coverage.
       - run: cargo clippy --workspace --all-targets --locked --features manifold-curvature,dec -- -D warnings
       - run: cargo test --workspace --locked --features manifold-curvature,dec
+      # dc-geometry in isolation: the documented `--features dc-geometry`
+      # invocation must build without nalgebra (which manifold-curvature and
+      # dec both pull in).
+      - run: cargo test --workspace --locked --features dc-geometry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this c
 Reboot alignment: irreducible becomes the example consumer of the
 rebooted catgraph's core + physics layer.
 
+### Added
+
+- **CI** (`.github/workflows/ci.yml`): fmt, clippy `-D warnings`,
+  tests on default features plus a `manifold-curvature,dec` feature
+  leg; private git-dep auth via a read-only deploy key +
+  `webfactory/ssh-agent`.
+- **`Cargo.lock` is now committed** (removed from `.gitignore`): CI
+  builds `--locked` for reproducible runs; cargo fetches every git
+  source in the lock, so the lock must never carry a git source CI
+  cannot authenticate to.
+
 ### Changed
 
 - **Docs reboot-aligned**: root `CLAUDE.md` is now a real public file
@@ -33,7 +44,10 @@ rebooted catgraph's core + physics layer.
   differential operators (`codifferential`, `laplacian`) source
   Hodge ⋆ from the Regge metric (a metric-less `Manifold` panics).
   Test-only fixes in `tests/dc_topology_smoke.rs` and
-  `tests/multiway_stokes.rs`.
+  `tests/multiway_stokes.rs`, plus `#[cfg(test)]`-scoped clippy fixes
+  in `src/test_utils.rs` (`$crate` macro hygiene) and
+  `src/machines/multiway/manifold_bridge.rs`.
+
 ### Removed
 
 - **`persist` feature removed pending the catgraph-surreal reboot**
@@ -45,14 +59,6 @@ rebooted catgraph's core + physics layer.
   catgraph — and its presence in the lock drags two additional private
   git sources into every CI fetch. The surface returns when
   catgraph-surreal is realigned.
-- **CI introduced** (`.github/workflows/ci.yml`): fmt, clippy
-  `-D warnings`, tests on default features plus a
-  `manifold-curvature,dec` feature leg; private git-dep auth via a
-  read-only deploy key + `webfactory/ssh-agent`.
-- **`Cargo.lock` is now committed** (removed from `.gitignore`): CI
-  builds `--locked` for reproducible runs; cargo fetches every git
-  source in the lock, so the lock must never carry a git source CI
-  cannot authenticate to.
 
 ## [0.6.5] - 2026-05-05
 

--- a/tests/multiway_stokes.rs
+++ b/tests/multiway_stokes.rs
@@ -168,11 +168,13 @@ mod dec_tests {
         );
     }
 
-    /// Build a small 2D simplicial complex by hand, equip it with unit-edge
-    /// Hodge star operators, wrap in a `Manifold`, and compute the
-    /// Hodge Laplacian on 0-forms via `manifold.laplacian(0)`. Densify the
-    /// resulting linear operator and verify that every eigenvalue is
-    /// non-negative (within numerical tolerance).
+    /// Build a small 2D simplicial complex by hand, attach a flat unit-edge
+    /// Regge metric, wrap in a `Manifold`, and compute the Hodge Laplacian
+    /// on 0-forms via `manifold.laplacian(0)`. Under dc_topology 0.6 the
+    /// differential operators source Hodge ⋆ from the metric; the unit Hodge
+    /// operators pre-supplied on the complex only satisfy `with_metric`'s
+    /// eager validation. Densify the resulting linear operator and verify
+    /// the spectrum is PSD with a strictly positive top eigenvalue.
     #[test]
     fn hodge_laplacian_spectrum_is_nonneg() {
         use deep_causality_tensor::CausalTensor;
@@ -259,6 +261,13 @@ mod dec_tests {
         assert!(
             max_eig.is_finite(),
             "max eigenvalue must be finite: {max_eig}"
+        );
+        // Guard against a silently-zero operator (e.g. a regression in the
+        // metric-sourced Hodge ⋆ path returning zero weights): the flat
+        // equilateral metric must produce a strictly positive doublet.
+        assert!(
+            max_eig > 1e-12,
+            "Hodge Laplacian must be nonzero on the unit triangle; max eigenvalue = {max_eig}"
         );
         // Spectrum shape on the single-unit-triangle complex: one ~0
         // eigenvalue (the constant 0-form, nullspace of d) and a positive


### PR DESCRIPTION
Post-merge review of the reboot-alignment delta (`4c94ada...main`) surfaced 6 verified findings; this applies 5:

1. **tests/multiway_stokes** — the 0.6 migration had weakened `hodge_laplacian_spectrum_is_nonneg` (an all-zero Laplacian passed its PSD+finite assertions). Now asserts `max_eig > 1e-12` and the doc comment reflects metric-sourced Hodge ⋆.
2. **CHANGELOG** — CI + Cargo.lock entries were misfiled under `### Removed`; moved to a new `### Added` section, missing blank line fixed, cfg(test) clippy fixes enumerated.
3. **ci.yml** — `push` filtered to main + concurrency cancel-in-progress (PR commits ran twice; stale runs never cancelled), and a new isolated `dc-geometry` test leg (the documented invocation was never built without nalgebra; 360 tests green locally).

**Not applied (surfaced for decision):** `deep_causality_num` 0.3.3 is locked twice — registry (via catgraph-applied's `=0.3.3` pin) + git (via the pinned deep_causality rev). Latent type-identity trap + double compile. The durable fix is upstream: catgraph #69 (pin bump `=0.3.3` → `=0.4.0`). A downstream `[patch.crates-io]` would unify sources today but risks diverging from what catgraph CI tests against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)