### PR TITLE
feat: compact closed witnesses for the Z' ⊣ Z adjunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ rebooted catgraph's core + physics layer.
 
 ### Added
 
+- **`CompactClosedWitness`** (`functor::adjunction`, re-exported at the
+  crate root): compact-closed witnesses for the Z' ⊣ Z adjunction
+  (F&S §3.1 + Prop 3.2, issue #13). The zigzag (snake) identities are
+  verified semantically in `Cospan<u32>` (pushout composition +
+  structural equality) at every boundary label of Z'(c)'s cospan, and
+  the Prop 3.2 name/unname round-trip is verified on the Frobenius
+  decomposition (`CospanToFrobeniusFunctor`) at the boundary level.
+  Evaluation outcome recorded on the issue: name/unname cannot
+  *replace* the semantic triangle checks — the free hypergraph
+  category carries no diagram normal form upstream, so full
+  string-diagram equality is undecidable there; the witnesses
+  strengthen rather than substitute. Also adds
+  `ZPrimeAdjunction::zprime_cospan` (the `to_cospan_chain`-compatible
+  single-interval encoding).
 - **CI** (`.github/workflows/ci.yml`): fmt, clippy `-D warnings`,
   tests on default features plus a `manifold-curvature,dec` feature
   leg; private git-dep auth via a read-only deploy key +

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ irreducible is the **example consumer of the [catgraph](https://github.com/susti
 | `temporal_cospan_chain.rs` | `TemporalComplex`, `ConservationResult`, `TemporalComplexError` (`StokesError` deprecated alias) | Cospan chain bridge for interval sequences (re-export shim into `catgraph_physics::temporal_cospan_chain` as of v0.6.3) |
 | `trace.rs` | `StepTrace`, `analyze_trace`, `RepeatDetection`, `is_irreducible` (`IrreducibilityTrace` deprecated alias) | Generic trace analysis, repeat detection (re-export shim into `catgraph_physics::trace` as of v0.6.3) |
 | `functor/mod.rs` | `IrreducibilityFunctor`, `MultiwayIrreducibilityResult` | Functor Z': T -> B, multiway branch analysis |
-| `functor/adjunction.rs` | `ZPrimeAdjunction`, `AdjunctionVerification` | Concrete Z' ⊣ Z adjunction for computation states |
+| `functor/adjunction.rs` | `ZPrimeAdjunction`, `AdjunctionVerification`, `CompactClosedWitness` | Concrete Z' ⊣ Z adjunction + compact-closed (cup/cap zigzag, Prop 3.2) witnesses |
 | `functor/monoidal.rs` | `MonoidalFunctorResult`, `TensorCheck` | Symmetric monoidal functor verification |
 | `functor/bifunctor.rs` | `TensorProduct`, `IntervalTransform` | Re-exports local bifunctor laws |
 | `functor/fong_spivak.rs` | `FrobeniusVerificationResult`, `verify_cospan_chain_frobenius` | Fong-Spivak Frobenius decomposition verification |

--- a/src/functor/adjunction.rs
+++ b/src/functor/adjunction.rs
@@ -1,12 +1,21 @@
 //! The Z' ⊣ Z Adjunction between Computation and Cobordism Categories.
 //!
 //! This module provides the concrete `ZPrimeAdjunction` implementation of the
-//! abstract adjunction framework from [`catgraph::adjunction`].
+//! abstract adjunction framework in [`crate::adjunction`], plus the
+//! compact-closed witness layer ([`CompactClosedWitness`]) tying the triangle
+//! identities to the cup/cap pairing of Fong-Spivak §3.1 (Prop 3.2).
 //!
 //! See Gorard's paper (Section 4.2) for the mathematical foundation.
 
 pub use crate::adjunction::{AdjunctionIrreducibility, AdjunctionVerification, ZPrimeOps};
+use crate::functor::fong_spivak::{
+    CospanToFrobeniusFunctor, HypergraphCategory, HypergraphFunctor, name, unname,
+};
 use crate::{computation_state::ComputationState, interval::DiscreteInterval};
+use catgraph::category::{Composable, ComposableMutating, HasIdentity};
+use catgraph::cospan::Cospan;
+use catgraph::errors::CatgraphError;
+use catgraph::monoidal::Monoidal;
 
 /// The Z' ⊣ Z adjunction between computation and cobordism categories.
 ///
@@ -68,6 +77,123 @@ impl ZPrimeOps for ZPrimeAdjunction {
 }
 
 impl AdjunctionIrreducibility for ZPrimeAdjunction {}
+
+/// Compact closed witness for the Z' ⊣ Z adjunction (F&S §3.1 + Prop 3.2).
+///
+/// In a self-dual compact closed category the unit and counit of the
+/// adjunction X ⊣ X are the cup/cap pairing, and the triangle identities
+/// are exactly the zigzag (snake) identities. B (cobordism intervals in
+/// their cospan encoding) is compact closed; this witness ties the
+/// semantic triangle checks in [`ZPrimeOps`] to that categorical
+/// structure.
+///
+/// The snake identities are verified *semantically* — cospan composition
+/// via pushout, compared by [`Cospan::structurally_equal`]. The Prop 3.2
+/// name/unname round-trip on the Frobenius decomposition is verified at
+/// the boundary level only: the free hypergraph category carries no
+/// diagram normal form upstream, so full string-diagram equality is not
+/// decidable there. The [`ZPrimeOps`] triangle checks therefore remain
+/// the equality backstop rather than being replaced.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct CompactClosedWitness {
+    /// Right snake `(id ⊗ cup) ; (cap ⊗ id) = id` at every boundary label
+    /// of Z'(c)'s cospan.
+    pub right_snake_holds: bool,
+    /// Left snake `(cup ⊗ id) ; (id ⊗ cap) = id` at every boundary label.
+    pub left_snake_holds: bool,
+    /// Prop 3.2 round-trip: `unname(name(f))` reproduces the boundaries
+    /// (domain and codomain) of the Frobenius decomposition of Z'(c)'s
+    /// cospan.
+    pub name_roundtrip_boundaries_hold: bool,
+}
+
+impl CompactClosedWitness {
+    /// True when every component witness holds.
+    #[must_use]
+    pub fn all_hold(&self) -> bool {
+        self.right_snake_holds && self.left_snake_holds && self.name_roundtrip_boundaries_hold
+    }
+}
+
+impl ZPrimeAdjunction {
+    /// Z'(c) as a cospan in the temporal-cospan-chain encoding: left
+    /// boundary {start}, right boundary {end}, apex {start, end}.
+    ///
+    /// Matches the per-interval encoding of
+    /// `TemporalComplex::to_cospan_chain`, so witnesses computed here are
+    /// consistent with the Stokes/cospan-chain perspective.
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn zprime_cospan(state: &ComputationState) -> Cospan<u32> {
+        let interval = Self::zprime(state);
+        Cospan::new(
+            vec![0],
+            vec![1],
+            vec![interval.start as u32, interval.end as u32],
+        )
+    }
+
+    /// Verify both snake identities for a single boundary label `z`,
+    /// returning `(right_snake, left_snake)`.
+    fn snake_identities_at(z: u32) -> Result<(bool, bool), CatgraphError> {
+        let id: Cospan<u32> = Cospan::identity(&vec![z]);
+        let cup = <Cospan<u32> as HypergraphCategory<u32>>::cup(z)?;
+        let cap = <Cospan<u32> as HypergraphCategory<u32>>::cap(z)?;
+
+        // Right snake: X ≅ X⊗I → X⊗X⊗X → I⊗X ≅ X.
+        let mut first = id.clone();
+        first.monoidal(cup.clone());
+        let mut second = cap.clone();
+        second.monoidal(id.clone());
+        let right = first.compose(&second)?;
+
+        // Left snake: X ≅ I⊗X → X⊗X⊗X → X⊗I ≅ X.
+        let mut first = cup;
+        first.monoidal(id.clone());
+        let mut second = id.clone();
+        second.monoidal(cap);
+        let left = first.compose(&second)?;
+
+        Ok((right.structurally_equal(&id), left.structurally_equal(&id)))
+    }
+
+    /// Compute the full compact-closed witness at a state: snake
+    /// identities at every boundary label of Z'(c)'s cospan, plus the
+    /// Prop 3.2 name/unname boundary round-trip on its Frobenius
+    /// decomposition (via [`CospanToFrobeniusFunctor`], Prop 3.8).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`CatgraphError`] from cospan composition or the
+    /// Frobenius decomposition; not expected for well-formed states.
+    pub fn verify_compact_closed_witness(
+        state: &ComputationState,
+    ) -> Result<CompactClosedWitness, CatgraphError> {
+        let cospan = Self::zprime_cospan(state);
+
+        let mut right_snake_holds = true;
+        let mut left_snake_holds = true;
+        for &z in cospan.middle() {
+            let (right, left) = Self::snake_identities_at(z)?;
+            right_snake_holds &= right;
+            left_snake_holds &= left;
+        }
+
+        let functor = CospanToFrobeniusFunctor::<()>::new();
+        let f = functor.map_mor(&cospan)?;
+        let named = name(&f)?;
+        let unnamed = unname(&named, f.domain().len())?;
+        let name_roundtrip_boundaries_hold =
+            unnamed.domain() == f.domain() && unnamed.codomain() == f.codomain();
+
+        Ok(CompactClosedWitness {
+            right_snake_holds,
+            left_snake_holds,
+            name_roundtrip_boundaries_hold,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -170,6 +296,38 @@ mod tests {
         let state = ComputationState::new(0, 5);
         let gap = ZPrimeAdjunction::adjunction_gap(&state);
         assert!(gap.abs() < f64::EPSILON, "Expected zero gap, got {}", gap);
+    }
+
+    #[test]
+    fn compact_closed_witness_holds_for_basic_state() {
+        let state = ComputationState::new(0, 5);
+        let witness = ZPrimeAdjunction::verify_compact_closed_witness(&state)
+            .expect("witness computation on well-formed state");
+        assert!(witness.right_snake_holds, "right snake must hold in Cospan");
+        assert!(witness.left_snake_holds, "left snake must hold in Cospan");
+        assert!(
+            witness.name_roundtrip_boundaries_hold,
+            "Prop 3.2 name/unname must preserve boundaries"
+        );
+        assert!(witness.all_hold());
+    }
+
+    #[test]
+    fn zprime_cospan_matches_temporal_chain_encoding() {
+        let state = ComputationState::new(3, 4);
+        let cospan = ZPrimeAdjunction::zprime_cospan(&state);
+        assert_eq!(cospan.left_to_middle(), &[0]);
+        assert_eq!(cospan.right_to_middle(), &[1]);
+        assert_eq!(cospan.middle(), &[3, 7]);
+    }
+
+    #[test]
+    fn compact_closed_witness_zero_complexity_state() {
+        // start == end: apex has duplicate labels; witness must still hold.
+        let state = ComputationState::new(4, 0);
+        let witness = ZPrimeAdjunction::verify_compact_closed_witness(&state)
+            .expect("witness on zero-complexity state");
+        assert!(witness.all_hold());
     }
 
     #[test]

--- a/src/functor/mod.rs
+++ b/src/functor/mod.rs
@@ -25,7 +25,8 @@ pub use monoidal::{MonoidalFunctorResult, TensorCheck};
 
 // Re-export adjunction types
 pub use adjunction::{
-    AdjunctionIrreducibility, AdjunctionVerification, ZPrimeAdjunction, ZPrimeOps,
+    AdjunctionIrreducibility, AdjunctionVerification, CompactClosedWitness, ZPrimeAdjunction,
+    ZPrimeOps,
 };
 
 // Re-export bifunctor types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,10 @@ pub use interval::{DiscreteInterval, ParallelIntervals};
 pub use functor::IrreducibilityFunctor;
 
 // Adjunction exports
-pub use functor::{AdjunctionIrreducibility, AdjunctionVerification, ZPrimeAdjunction, ZPrimeOps};
+pub use functor::{
+    AdjunctionIrreducibility, AdjunctionVerification, CompactClosedWitness, ZPrimeAdjunction,
+    ZPrimeOps,
+};
 
 // Monoidal functor exports
 pub use functor::{MonoidalFunctorResult, TensorCheck};

--- a/tests/adjunction_laws.rs
+++ b/tests/adjunction_laws.rs
@@ -154,3 +154,67 @@ fn irreducibility_indicator_averages() {
     let empty = SimpleAdjunction::adjunction_irreducibility_indicator(&[]);
     assert!((empty - 0.0).abs() < 1e-10);
 }
+
+// ---------------------------------------------------------------------------
+// Compact closed witness (F&S §3.1 + Prop 3.2) — issue #13
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compact_closed_witness_holds_along_walk() {
+    use irreducible::{CompactClosedWitness, ZPrimeAdjunction};
+
+    let states = make_walk(6);
+    for s in &states {
+        let witness: CompactClosedWitness = ZPrimeAdjunction::verify_compact_closed_witness(s)
+            .expect("witness computation along walk");
+        assert!(
+            witness.all_hold(),
+            "compact closed witness failed at step {}: {witness:?}",
+            s.step
+        );
+    }
+}
+
+#[test]
+fn compact_closed_witness_agrees_with_triangle_identities() {
+    use irreducible::{ZPrimeAdjunction, ZPrimeOps};
+
+    // The zigzag identities are the categorical form of the triangle
+    // identities; on well-formed states both verifications must agree.
+    let states = make_walk(4);
+    for s in &states {
+        let triangles = ZPrimeAdjunction::verify_triangle_1(s) && {
+            let i = ZPrimeAdjunction::zprime(s);
+            ZPrimeAdjunction::verify_triangle_2(&i)
+        };
+        let witness =
+            ZPrimeAdjunction::verify_compact_closed_witness(s).expect("witness computation");
+        assert_eq!(
+            triangles,
+            witness.all_hold(),
+            "triangle identities and compact closed witness disagree at step {}",
+            s.step
+        );
+    }
+}
+
+#[test]
+fn zprime_cospan_composes_along_contiguous_walk() {
+    use catgraph::category::Composable;
+    use irreducible::ZPrimeAdjunction;
+
+    // Adjacent Z'-cospans of a contiguous walk share boundary labels and
+    // must compose (the categorical form of interval contiguity). Each
+    // state starts where the previous interval ended.
+    let states = [
+        ComputationState::new(0, 2), // [0, 2]
+        ComputationState::new(2, 3), // [2, 5]
+        ComputationState::new(5, 1), // [5, 6]
+    ];
+    let cospans: Vec<_> = states.iter().map(ZPrimeAdjunction::zprime_cospan).collect();
+    for pair in cospans.windows(2) {
+        pair[0]
+            .compose(&pair[1])
+            .expect("contiguous Z'-cospans must compose");
+    }
+}


### PR DESCRIPTION
Closes #13.

## Evaluation (acceptance item 1)

`name`/`unname` (F&S Prop 3.2) **cannot replace** the semantic triangle checks in `ZPrimeOps`: the free hypergraph category (`FrobeniusMorphism`) carries no diagram normal form upstream, so full string-diagram equality is undecidable — catgraph's own `unname(name(f))` round-trip test asserts domain/codomain only. A replacement would have silently weakened verification from exact semantic equality to boundary equality.

## What ships instead (strengthening, not substitution)

`CompactClosedWitness` + `ZPrimeAdjunction::{zprime_cospan, verify_compact_closed_witness}`:

- **Snake identities, semantically**: `(id ⊗ cup);(cap ⊗ id) = id` and `(cup ⊗ id);(id ⊗ cap) = id` verified in `Cospan<u32>` — where cup/cap come from the `HypergraphCategory` impl (Thm 3.14), composition is pushout, and equality is `structurally_equal`. Checked at every boundary label of Z'(c)'s cospan. These zigzags are exactly the triangle identities of the self-dual compact closed adjunction — the categorical form of what `verify_triangle_1/2` check numerically.
- **Prop 3.2 round-trip**: `unname(name(f))` preserves boundaries, with `f` the `CospanToFrobeniusFunctor` (Prop 3.8) decomposition of Z'(c)'s cospan — exercising the compact-closed + Frobenius stack end to end. Boundary-level scope documented on the field.
- `zprime_cospan` uses the same single-interval encoding as `TemporalComplex::to_cospan_chain`, keeping the witness consistent with the Stokes/cospan-chain perspective; a new test shows contiguous Z'-cospans compose (the categorical form of interval contiguity).

## Acceptance
- [x] Evaluate name/unname simplification → **negative** (recorded above + in CHANGELOG); cup/cap zigzag witnesses shipped instead
- [x] Public `AdjunctionVerification` shape unchanged; `ZPrimeOps` untouched
- [x] No regressions in `tests/adjunction_laws.rs` — all pre-existing tests pass unchanged; +3 integration, +3 unit tests

Gates: 360 default / 387 feature-leg tests, clippy `-D warnings` both legs, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)