### PR TITLE
feat: Frobenius preservation for Z' — HypergraphFunctor impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ rebooted catgraph's core + physics layer.
 
 ### Added
 
+- **Frobenius preservation for Z'**
+  (`functor::frobenius_preservation`, issue #12):
+  `IrreducibilityFunctor` now implements `HypergraphFunctor` on the
+  free hypergraph category (identity on labels and cospan shapes —
+  Gorard's Z' forgets computational content, keeps event structure),
+  and `verify_frobenius_preservation` checks the decidable Eq. 12
+  slice: the four generator equations at cospan level AND through
+  `CospanToFrobeniusFunctor` (Prop 3.8), per-event spider
+  factorization ((l−1) μ then ε or (r−1) δ, compared against pushout
+  composition), and boundary preservation of every step-cospan
+  decomposition. Evaluation outcome: T's Frobenius generators are the
+  multiway event types (μ = merge, δ = fork, ε = branch death,
+  η = root creation); both T and B are hypergraph categories by
+  encoding into `Cospan<u32>` (Thm 3.14) rather than via new trait
+  impls on machine types. TM + CA + fork/merge SRS coverage in
+  `tests/frobenius_preservation.rs`.
 - **`IntervalCospanAlgebra` + `multiway_step_cospans`**
   (`functor::interval_algebra`, re-exported from `functor`): Z' as a
   cospan-algebra (F&S §2.1 Def 2.2, issue #11). The carrier is

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ irreducible is the **example consumer of the [catgraph](https://github.com/susti
 | `functor/adjunction.rs` | `ZPrimeAdjunction`, `AdjunctionVerification`, `CompactClosedWitness` | Concrete Z' ⊣ Z adjunction + compact-closed (cup/cap zigzag, Prop 3.2) witnesses |
 | `functor/monoidal.rs` | `MonoidalFunctorResult`, `TensorCheck` | Symmetric monoidal functor verification |
 | `functor/interval_algebra.rs` | `IntervalCospanAlgebra`, `multiway_step_cospans` | Z' as a cospan-algebra (F&S Def 2.2): interval-bundle transport over multiway step cospans |
+| `functor/frobenius_preservation.rs` | `FrobeniusPreservationResult`, `verify_frobenius_preservation` | Z' as a hypergraph functor: Eq. 12 generator preservation + per-event spider factorization (μ = merge, δ = fork, ε = death) |
 | `functor/bifunctor.rs` | `TensorProduct`, `IntervalTransform` | Re-exports local bifunctor laws |
 | `functor/fong_spivak.rs` | `FrobeniusVerificationResult`, `verify_cospan_chain_frobenius` | Fong-Spivak Frobenius decomposition verification |
 | `functor/stokes_integration.rs` | `StokesIrreducibility` | Stokes conservation analysis wrapper |

--- a/src/functor/frobenius_preservation.rs
+++ b/src/functor/frobenius_preservation.rs
@@ -1,0 +1,363 @@
+//! Frobenius preservation for Z': T → B (F&S §2.3 Eq. 12; issue #12).
+//!
+//! ## Evaluation outcome (acceptance item 1)
+//!
+//! Both categories are structured as hypergraph categories **by encoding
+//! into the free one** (Thm 3.14): T-morphisms are the multiway step
+//! cospans of [`multiway_step_cospans`](super::interval_algebra::multiway_step_cospans)
+//! and B-morphisms are cobordism cospans — both `Cospan<u32>`, which
+//! carries the `HypergraphCategory` impl. Under this encoding the Frobenius
+//! generators of T **are the multiway event types**:
+//!
+//! | generator | multiway event |
+//! |---|---|
+//! | μ (multiplication) | merge (two branches reach one state) |
+//! | δ (comultiplication) | fork (one state rewrites two ways) |
+//! | ε (counit) | branch death (no continuation) |
+//! | η (unit) | branch creation (the root; never mid-evolution) |
+//!
+//! Z' itself acts on these shapes as the **identity hypergraph functor**
+//! (label map `id`, morphism map `clone`): Gorard's Z' forgets the
+//! computational content of states but preserves the entire boundary /
+//! event structure — the interval content lives in the cospan-algebra
+//! action ([`IntervalCospanAlgebra`](super::interval_algebra::IntervalCospanAlgebra)),
+//! not in the cospan shape. The trait laws (Eq. 12, functoriality,
+//! monoidality) are not enforced by the compiler; [`verify_frobenius_preservation`]
+//! checks them where they are decidable:
+//!
+//! 1. **Eq. 12 on generators**, twice: at the cospan level
+//!    (`map_mor(gen_T) ≟ gen_B`, via `structurally_equal`) and through
+//!    [`CospanToFrobeniusFunctor`] (Prop 3.8: the decomposition of a
+//!    generator cospan must be that generator, via `FrobeniusMorphism`
+//!    equality).
+//! 2. **Spider factorization per event**: every apex component (l parents,
+//!    r children) must equal the pushout composite of its Frobenius
+//!    generator recipe — (l−1) multiplications, then either a counit
+//!    (r = 0, branch death) or (r−1) comultiplications. This is the
+//!    falsifiable Prop 3.8 content at cospan level.
+//! 3. **Boundary preservation through decomposition**: `cospan_to_frobenius`
+//!    of each step cospan reproduces the cospan's boundaries (the decidable
+//!    slice — the free hypergraph category has no diagram normal form
+//!    upstream, so full string-diagram equality is out of reach; same
+//!    limitation recorded on issues #13/#11).
+//!
+//! Whole-step reassembly (⊗ of component spiders ≟ step cospan) is *not*
+//! checked: branchial node order may interleave components, so reassembly
+//! requires braiding permutations — deferred until a consumer needs it.
+
+use std::hash::Hash;
+
+use catgraph::category::{Composable, ComposableMutating, HasIdentity};
+use catgraph::cospan::Cospan;
+use catgraph::errors::CatgraphError;
+use catgraph::frobenius::FrobeniusMorphism;
+use catgraph::hypergraph_category::HypergraphCategory;
+use catgraph::hypergraph_functor::{CospanToFrobeniusFunctor, HypergraphFunctor};
+use catgraph::monoidal::Monoidal;
+use catgraph_physics::multiway::MultiwayEvolutionGraph;
+
+use super::IrreducibilityFunctor;
+use super::interval_algebra::multiway_step_cospans;
+
+/// Z' as a hypergraph functor on the free hypergraph category (Thm 3.14):
+/// identity on labels, identity on cospan shapes. See the
+/// [module docs](self) for why this is the honest encoding of Gorard's Z'
+/// at the shape level.
+impl HypergraphFunctor<u32, u32, Cospan<u32>, Cospan<u32>> for IrreducibilityFunctor {
+    fn map_ob(&self, x: u32) -> u32 {
+        x
+    }
+
+    fn map_mor(&self, f: &Cospan<u32>) -> Result<Cospan<u32>, CatgraphError> {
+        Ok(f.clone())
+    }
+}
+
+/// Result of Frobenius-preservation verification for Z' (Eq. 12).
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct FrobeniusPreservationResult {
+    /// Eq. 12 for η at the cospan level and through the Prop 3.8 functor.
+    pub unit_preserved: bool,
+    /// Eq. 12 for ε.
+    pub counit_preserved: bool,
+    /// Eq. 12 for μ.
+    pub multiplication_preserved: bool,
+    /// Eq. 12 for δ.
+    pub comultiplication_preserved: bool,
+    /// `cospan_to_frobenius` of every step cospan reproduces its boundaries.
+    pub decomposition_boundaries_preserved: bool,
+    /// Per-step spider-factorization checks.
+    pub per_step: Vec<StepFrobeniusCheck>,
+}
+
+impl FrobeniusPreservationResult {
+    /// True when every generator equation, boundary check, and per-step
+    /// factorization holds.
+    #[must_use]
+    pub fn all_hold(&self) -> bool {
+        self.unit_preserved
+            && self.counit_preserved
+            && self.multiplication_preserved
+            && self.comultiplication_preserved
+            && self.decomposition_boundaries_preserved
+            && self.per_step.iter().all(|s| s.factorizations_hold)
+    }
+}
+
+/// Spider-factorization check for one evolution step.
+#[derive(Clone, Debug)]
+pub struct StepFrobeniusCheck {
+    /// The time step.
+    pub step: usize,
+    /// Number of apex components (events) checked at this step.
+    pub components_checked: usize,
+    /// Whether every event factored through its Frobenius generator recipe.
+    pub factorizations_hold: bool,
+}
+
+/// The single label of the single-typed step-cospan encoding.
+const Z: u32 = 0;
+
+/// Build the Frobenius generator recipe for an (l, r) spider in `Cospan`:
+/// (l−1) multiplications folding l wires to one, then a counit if `r == 0`
+/// or (r−1) comultiplications expanding to r wires.
+///
+/// Requires `l >= 1` (multiway events always have at least one parent).
+fn spider_recipe(l: usize, r: usize) -> Result<Cospan<u32>, CatgraphError> {
+    let mut composite: Cospan<u32> = Cospan::identity(&vec![Z; l]);
+
+    // Fold: w wires -> w-1 wires via mu ⊗ id^(w-2).
+    let mut w = l;
+    while w > 1 {
+        let mut layer = Cospan::multiplication(Z);
+        layer.monoidal(Cospan::identity(&vec![Z; w - 2]));
+        composite = composite.compose(&layer)?;
+        w -= 1;
+    }
+
+    if r == 0 {
+        // Branch death: cap the surviving wire.
+        composite = composite.compose(&Cospan::counit(Z))?;
+    } else {
+        // Expand: w wires -> w+1 wires via delta ⊗ id^(w-1).
+        while w < r {
+            let mut layer = Cospan::comultiplication(Z);
+            layer.monoidal(Cospan::identity(&vec![Z; w - 1]));
+            composite = composite.compose(&layer)?;
+            w += 1;
+        }
+    }
+
+    Ok(composite)
+}
+
+/// The (l, r) spider as a single-apex cospan — the shape every multiway
+/// event takes inside a step cospan.
+fn spider_cospan(l: usize, r: usize) -> Cospan<u32> {
+    Cospan::new(vec![0; l], vec![0; r], vec![Z])
+}
+
+/// Eq. 12 for one generator: the functor's image at the cospan level must
+/// be the target generator, and the Prop 3.8 decomposition of the generator
+/// cospan must be the generator `FrobeniusMorphism`.
+fn generator_preserved(
+    functor: &IrreducibilityFunctor,
+    decomposer: &CospanToFrobeniusFunctor<()>,
+    source: &Cospan<u32>,
+    target_frobenius: &FrobeniusMorphism<u32, ()>,
+) -> Result<bool, CatgraphError> {
+    let mapped: Cospan<u32> = functor.map_mor(source)?;
+    let cospan_level = mapped.structurally_equal(source);
+
+    let decomposed: FrobeniusMorphism<u32, ()> = decomposer.map_mor(&mapped)?;
+    let frobenius_level = decomposed == *target_frobenius;
+
+    Ok(cospan_level && frobenius_level)
+}
+
+/// Verify that Z' preserves Frobenius structure on a multiway evolution
+/// (F&S §2.3 Eq. 12 + Prop 3.8). See the [module docs](self) for exactly
+/// what is decidable and checked.
+///
+/// # Errors
+///
+/// Propagates [`CatgraphError`] from cospan composition or decomposition;
+/// also errors if a step cospan contains an event with no parent branch
+/// (a spontaneous creation mid-evolution, which multiway BFS never
+/// produces).
+pub fn verify_frobenius_preservation<S: Clone + Hash, T: Clone>(
+    graph: &MultiwayEvolutionGraph<S, T>,
+) -> Result<FrobeniusPreservationResult, CatgraphError> {
+    let functor = IrreducibilityFunctor::new();
+    let decomposer = CospanToFrobeniusFunctor::<()>::new();
+
+    // Eq. 12 on the four generators.
+    let unit_preserved = generator_preserved(
+        &functor,
+        &decomposer,
+        &Cospan::unit(Z),
+        &FrobeniusMorphism::unit(Z),
+    )?;
+    let counit_preserved = generator_preserved(
+        &functor,
+        &decomposer,
+        &Cospan::counit(Z),
+        &FrobeniusMorphism::counit(Z),
+    )?;
+    let multiplication_preserved = generator_preserved(
+        &functor,
+        &decomposer,
+        &Cospan::multiplication(Z),
+        &FrobeniusMorphism::multiplication(Z),
+    )?;
+    let comultiplication_preserved = generator_preserved(
+        &functor,
+        &decomposer,
+        &Cospan::comultiplication(Z),
+        &FrobeniusMorphism::comultiplication(Z),
+    )?;
+
+    // Per-step: boundary preservation through decomposition + spider
+    // factorization per apex component.
+    let chain = multiway_step_cospans(graph);
+    let mut decomposition_boundaries_preserved = true;
+    let mut per_step = Vec::with_capacity(chain.len());
+
+    for (step, cospan) in chain.iter().enumerate() {
+        let image: Cospan<u32> = functor.map_mor(cospan)?;
+
+        let decomposed: FrobeniusMorphism<u32, ()> = decomposer.map_mor(&image)?;
+        let expected_domain = vec![Z; image.left_to_middle().len()];
+        let expected_codomain = vec![Z; image.right_to_middle().len()];
+        if decomposed.domain() != expected_domain || decomposed.codomain() != expected_codomain {
+            decomposition_boundaries_preserved = false;
+        }
+
+        // Census per apex vertex: (l parents, r children).
+        let apex_count = image.middle().len();
+        let mut lefts = vec![0usize; apex_count];
+        let mut rights = vec![0usize; apex_count];
+        for &a in image.left_to_middle() {
+            lefts[a] += 1;
+        }
+        for &a in image.right_to_middle() {
+            rights[a] += 1;
+        }
+
+        let mut factorizations_hold = true;
+        let mut components_checked = 0;
+        for (l, r) in lefts.iter().copied().zip(rights.iter().copied()) {
+            if l == 0 && r == 0 {
+                continue; // unreachable: apex vertices come from boundary nodes
+            }
+            if l == 0 {
+                return Err(CatgraphError::Composition {
+                    message: format!(
+                        "step {step}: event with {r} children but no parent branch; \
+                         spontaneous creation is not a multiway event"
+                    ),
+                });
+            }
+            components_checked += 1;
+            let recipe = spider_recipe(l, r)?;
+            if !recipe.structurally_equal(&spider_cospan(l, r)) {
+                factorizations_hold = false;
+            }
+        }
+
+        per_step.push(StepFrobeniusCheck {
+            step,
+            components_checked,
+            factorizations_hold,
+        });
+    }
+
+    Ok(FrobeniusPreservationResult {
+        unit_preserved,
+        counit_preserved,
+        multiplication_preserved,
+        comultiplication_preserved,
+        decomposition_boundaries_preserved,
+        per_step,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::machines::multiway::StringRewriteSystem;
+
+    #[test]
+    fn generator_recipes_reproduce_spiders() {
+        // Sequential event: identity wire.
+        assert!(
+            spider_recipe(1, 1)
+                .unwrap()
+                .structurally_equal(&spider_cospan(1, 1))
+        );
+        // Fork: delta.
+        assert!(
+            spider_recipe(1, 2)
+                .unwrap()
+                .structurally_equal(&spider_cospan(1, 2))
+        );
+        // Merge: mu.
+        assert!(
+            spider_recipe(2, 1)
+                .unwrap()
+                .structurally_equal(&spider_cospan(2, 1))
+        );
+        // Branch death: epsilon.
+        assert!(
+            spider_recipe(1, 0)
+                .unwrap()
+                .structurally_equal(&spider_cospan(1, 0))
+        );
+        // Wide events: 3-way fork, 3-way merge, merge-then-fork.
+        assert!(
+            spider_recipe(1, 3)
+                .unwrap()
+                .structurally_equal(&spider_cospan(1, 3))
+        );
+        assert!(
+            spider_recipe(3, 1)
+                .unwrap()
+                .structurally_equal(&spider_cospan(3, 1))
+        );
+        assert!(
+            spider_recipe(2, 2)
+                .unwrap()
+                .structurally_equal(&spider_cospan(2, 2))
+        );
+        // Dying merge: two parents, no children.
+        assert!(
+            spider_recipe(2, 0)
+                .unwrap()
+                .structurally_equal(&spider_cospan(2, 0))
+        );
+    }
+
+    #[test]
+    fn frobenius_preservation_on_forking_srs() {
+        let srs = StringRewriteSystem::new(vec![("A", "AB"), ("A", "BA")]);
+        let evolution = srs.run_multiway("A", 3, 32);
+        let result = verify_frobenius_preservation(&evolution).expect("verification runs");
+        assert!(result.unit_preserved);
+        assert!(result.counit_preserved);
+        assert!(result.multiplication_preserved);
+        assert!(result.comultiplication_preserved);
+        assert!(result.all_hold(), "{result:?}");
+        // The fork at step 0 must have been checked as a real event.
+        assert!(result.per_step[0].components_checked >= 1);
+    }
+
+    #[test]
+    fn frobenius_preservation_on_merging_srs() {
+        // Cyclic swap: branches re-converge on shared states (merges).
+        let srs = StringRewriteSystem::new(vec![("AB", "BA"), ("BA", "AB")]);
+        let evolution = srs.run_multiway("AB", 4, 32);
+        let result = verify_frobenius_preservation(&evolution).expect("verification runs");
+        assert!(result.all_hold(), "{result:?}");
+    }
+}

--- a/src/functor/mod.rs
+++ b/src/functor/mod.rs
@@ -17,6 +17,7 @@
 pub mod adjunction;
 pub mod bifunctor;
 pub mod fong_spivak;
+pub mod frobenius_preservation;
 pub mod interval_algebra;
 pub mod monoidal;
 pub mod stokes_integration;
@@ -26,6 +27,11 @@ pub use monoidal::{MonoidalFunctorResult, TensorCheck};
 
 // Re-export the Z' cospan-algebra surface (F&S Def 2.2).
 pub use interval_algebra::{IntervalCospanAlgebra, multiway_step_cospans};
+
+// Re-export the Frobenius-preservation surface (F&S Eq. 12).
+pub use frobenius_preservation::{
+    FrobeniusPreservationResult, StepFrobeniusCheck, verify_frobenius_preservation,
+};
 
 // Re-export adjunction types
 pub use adjunction::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,12 @@ pub use functor::{
 // Monoidal functor exports
 pub use functor::{MonoidalFunctorResult, TensorCheck};
 
+// Z' cospan-algebra + Frobenius-preservation exports
+pub use functor::{
+    FrobeniusPreservationResult, IntervalCospanAlgebra, StepFrobeniusCheck, multiway_step_cospans,
+    verify_frobenius_preservation,
+};
+
 // Bifunctor / tensor product exports
 pub use functor::{
     IntervalTransform, TensorProduct, tensor_bimap, tensor_first, tensor_second,

--- a/tests/frobenius_preservation.rs
+++ b/tests/frobenius_preservation.rs
@@ -1,0 +1,89 @@
+//! Integration tests for Frobenius preservation of Z' (issue #12).
+//!
+//! Acceptance: at least one TM and one CA test where the
+//! unit/counit/multiplication/comultiplication on the source side match
+//! those on the target side after applying Z', plus multiway systems with
+//! genuine fork/merge events.
+
+use irreducible::machines::multiway::MultiwayEvolutionGraph;
+use irreducible::machines::{ElementaryCA, TuringMachine};
+use irreducible::trace::StepTrace;
+use irreducible::{StringRewriteSystem, verify_frobenius_preservation};
+
+/// Lift a linear execution trace into a (single-track) multiway graph.
+fn linear_graph(fingerprints: &[u64]) -> MultiwayEvolutionGraph<u64, ()> {
+    let mut graph = MultiwayEvolutionGraph::new();
+    let mut node = graph.add_root(fingerprints[0]);
+    for &fp in &fingerprints[1..] {
+        node = graph.add_sequential_step(node, fp, ());
+    }
+    graph
+}
+
+fn assert_generators_preserved<S: Clone + std::hash::Hash, T: Clone>(
+    graph: &MultiwayEvolutionGraph<S, T>,
+    name: &str,
+) {
+    let result = verify_frobenius_preservation(graph).expect("verification runs");
+    assert!(result.unit_preserved, "{name}: eta not preserved");
+    assert!(result.counit_preserved, "{name}: epsilon not preserved");
+    assert!(result.multiplication_preserved, "{name}: mu not preserved");
+    assert!(
+        result.comultiplication_preserved,
+        "{name}: delta not preserved"
+    );
+    assert!(result.all_hold(), "{name}: {result:?}");
+}
+
+#[test]
+fn turing_machine_execution_preserves_frobenius_structure() {
+    let bb = TuringMachine::busy_beaver_2_2();
+    let history = bb.run("", 20);
+    let graph = linear_graph(&history.state_fingerprints());
+
+    assert_generators_preserved(&graph, "busy beaver 2,2");
+
+    // A single-track trace has exactly one sequential event per step.
+    let result = verify_frobenius_preservation(&graph).expect("verification runs");
+    for check in &result.per_step {
+        assert_eq!(
+            check.components_checked, 1,
+            "TM trace must be one sequential event per step"
+        );
+    }
+}
+
+#[test]
+fn cellular_automaton_execution_preserves_frobenius_structure() {
+    let ca = ElementaryCA::rule_30(21);
+    let history = ca.run(ca.single_cell_initial(), 20);
+    let graph = linear_graph(&history.state_fingerprints());
+
+    assert_generators_preserved(&graph, "rule 30");
+}
+
+#[test]
+fn forking_srs_preserves_frobenius_structure() {
+    let srs = StringRewriteSystem::new(vec![("A", "AB"), ("A", "BA")]);
+    let evolution = srs.run_multiway("A", 4, 64);
+    assert_generators_preserved(&evolution, "forking SRS");
+
+    // The step-0 fork must appear as a checked event.
+    let result = verify_frobenius_preservation(&evolution).expect("verification runs");
+    assert!(result.per_step[0].components_checked >= 1);
+}
+
+#[test]
+fn merging_srs_preserves_frobenius_structure() {
+    // Cyclic swap re-converges branches onto shared states (merge events).
+    let srs = StringRewriteSystem::new(vec![("AB", "BA"), ("BA", "AB")]);
+    let evolution = srs.run_multiway("AB", 4, 32);
+    assert_generators_preserved(&evolution, "merging SRS");
+}
+
+#[test]
+fn branching_and_growth_srs_preserves_frobenius_structure() {
+    let srs = StringRewriteSystem::new(vec![("AB", "BA"), ("A", "AA")]);
+    let evolution = srs.run_multiway("AB", 4, 64);
+    assert_generators_preserved(&evolution, "branch+growth SRS");
+}


### PR DESCRIPTION
Closes #12.

## Evaluation (acceptance item 1)

**Can T and B both be HypergraphCategory instances?** Yes — **by encoding into the free hypergraph category** (Thm 3.14) rather than via new trait impls on machine types: T-morphisms are the `multiway_step_cospans` chain (#11), B-morphisms cobordism cospans, both `Cospan<u32>`. Under this encoding **T's Frobenius generators are the multiway event types**:

| generator | multiway event |
|---|---|
| μ | merge |
| δ | fork |
| ε | branch death |
| η | root creation |

Z' acts on these shapes as the **identity hypergraph functor** (labels `id`, morphisms `clone`) — Gorard's Z' forgets computational content while preserving the entire event structure; the interval content lives in the #11 cospan-algebra action.

## What ships (acceptance items 2–3)

- `impl HypergraphFunctor<u32, u32, Cospan<u32>, Cospan<u32>> for IrreducibilityFunctor`.
- `verify_frobenius_preservation` — the decidable Eq. 12 slice:
  1. **Four generator equations**, checked twice: cospan-level (`structurally_equal`) and through `CospanToFrobeniusFunctor` with `FrobeniusMorphism` equality (Prop 3.8) — the decomposition of each generator cospan must be exactly that generator.
  2. **Per-event spider factorization**: every apex component (l parents, r children) must equal the pushout composite of its generator recipe — (l−1) μ, then ε (r=0) or (r−1) δ. Falsifiable Prop 3.8 content at cospan level.
  3. **Boundary preservation** of every step-cospan decomposition (the free hypergraph category has no diagram normal form upstream — same decidability boundary recorded on #13/#11).
- Whole-step reassembly (⊗ of component spiders ≟ step cospan) deferred: interleaved branchial node order needs braiding permutations; documented in the module.

## Tests (acceptance item 4)

TM (busy beaver 2,2) and CA (rule 30) traces lifted to single-track multiway graphs — all four generators match after applying Z', with exactly one sequential event per step — plus forking, merging (cyclic swap), and branch+growth SRS evolutions exercising real μ/δ events.

Gates: 383 default / 410 feature-leg tests, clippy `-D warnings` both legs, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)