### PR TITLE
feat: merge partitions as corelations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ rebooted catgraph's core + physics layer.
 
 ### Added
 
+- **Corelations for multiway merge events** (`functor::corel` +
+  `MergesCorelExt` on `MultiwayCospanGraph`; F&S 2018 Ex 6.64,
+  issue #14). `step_corels` lifts the step-cospan chain to
+  corelations, **gluing fingerprint-coincident states** (the multiway
+  explorer keeps same-state nodes distinct, so merges exist only at
+  the fingerprint level — the corelation records their
+  identification); `evolution_corel` composes the chain into one
+  whole-evolution partition. On the hypergraph side,
+  `MergesCorelExt::merges_corel[_over]` exposes the merge partition
+  over vertex IDs (merge-point states aligned by sorted vertex-ID
+  order — an approximation where an isomorphism permutes IDs
+  non-monotonically, documented), and restricting two rule-ordering
+  runs to the shared initial vertices makes their partitions
+  comparable via `Corel::coarsest_common_refinement` — a candidate
+  confluence test stronger than the Wilson-loop check. `Corel` and
+  helpers re-exported at the crate root.
 - **Frobenius preservation for Z'**
   (`functor::frobenius_preservation`, issue #12):
   `IrreducibilityFunctor` now implements `HypergraphFunctor` on the

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ irreducible is the **example consumer of the [catgraph](https://github.com/susti
 | `functor/monoidal.rs` | `MonoidalFunctorResult`, `TensorCheck` | Symmetric monoidal functor verification |
 | `functor/interval_algebra.rs` | `IntervalCospanAlgebra`, `multiway_step_cospans` | Z' as a cospan-algebra (F&S Def 2.2): interval-bundle transport over multiway step cospans |
 | `functor/frobenius_preservation.rs` | `FrobeniusPreservationResult`, `verify_frobenius_preservation` | Z' as a hypergraph functor: Eq. 12 generator preservation + per-event spider factorization (μ = merge, δ = fork, ε = death) |
+| `functor/corel.rs` | `Corel`, `step_corels`, `evolution_corel` | Merge partitions as corelations (F&S 2018 Ex 6.64) with fingerprint gluing; hypergraph-side `MergesCorelExt` adds `coarsest_common_refinement` confluence comparison |
 | `functor/bifunctor.rs` | `TensorProduct`, `IntervalTransform` | Re-exports local bifunctor laws |
 | `functor/fong_spivak.rs` | `FrobeniusVerificationResult`, `verify_cospan_chain_frobenius` | Fong-Spivak Frobenius decomposition verification |
 | `functor/stokes_integration.rs` | `StokesIrreducibility` | Stokes conservation analysis wrapper |

--- a/src/functor/corel.rs
+++ b/src/functor/corel.rs
@@ -1,0 +1,206 @@
+//! Corelations for multiway merge events (F&S 2018 Ex 6.64; issue #14).
+//!
+//! A [`Corel`] is a jointly-surjective cospan — a partition of its boundary.
+//! Multiway step cospans ([`multiway_step_cospans`]) are jointly surjective
+//! by construction, so each step lifts to a corelation whose classes are the
+//! step's events — and [`step_corels`] additionally **glues
+//! fingerprint-coincident states**: the multiway explorer keeps same-state
+//! nodes reached along different paths as distinct graph nodes, so merge
+//! events exist only at the fingerprint level, and the corelation is exactly
+//! the structure that records their identification. A merge therefore
+//! appears as one class containing both parent branches; a fork as one class
+//! containing both children.
+//!
+//! [`evolution_corel`] composes the chain into a single corelation from the
+//! initial branchial slice to the final one — two positions share a class
+//! iff their histories are causally connected through shared or
+//! fingerprint-identified events.
+//!
+//! The raw (merge-blind) event chain remains available via
+//! [`multiway_step_cospans`] — it is the substrate of the Frobenius event
+//! census (issue #12) and must reflect graph edges only.
+//!
+//! The hypergraph-evolution counterpart (merge partition over hypergraph
+//! *vertex IDs*, cross-run comparison via
+//! [`Corel::coarsest_common_refinement`]) lives in
+//! [`crate::machines::hypergraph::catgraph_bridge`].
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+pub use catgraph::corel::Corel;
+
+use catgraph::category::Composable;
+use catgraph::cospan::Cospan;
+use catgraph::errors::CatgraphError;
+use catgraph_physics::multiway::{MultiwayEvolutionGraph, extract_branchial_foliation};
+
+use super::interval_algebra::multiway_step_cospans;
+
+/// Lift every multiway step cospan to a corelation, gluing
+/// fingerprint-coincident states of the target slice (merge events).
+///
+/// # Errors
+///
+/// Returns [`CatgraphError::Corel`] if a quotiented step cospan is not
+/// jointly surjective — impossible by construction, so an error indicates a
+/// bug in the step-cospan or quotient construction.
+pub fn step_corels<S: Clone + Hash, T: Clone>(
+    graph: &MultiwayEvolutionGraph<S, T>,
+) -> Result<Vec<Corel<u32>>, CatgraphError> {
+    let foliation = extract_branchial_foliation(graph);
+    multiway_step_cospans(graph)
+        .into_iter()
+        .enumerate()
+        .map(|(i, cospan)| {
+            let glued = glue_fingerprint_merges(graph, &foliation[i + 1], &cospan);
+            Corel::new(glued)
+        })
+        .collect()
+}
+
+/// Compose the whole evolution into one corelation from the initial
+/// branchial slice to the final one. Returns `None` for evolutions with
+/// fewer than one step.
+///
+/// # Errors
+///
+/// Propagates [`CatgraphError`] from corelation composition (pushout).
+pub fn evolution_corel<S: Clone + Hash, T: Clone>(
+    graph: &MultiwayEvolutionGraph<S, T>,
+) -> Result<Option<Corel<u32>>, CatgraphError> {
+    let mut chain = step_corels(graph)?.into_iter();
+    let Some(first) = chain.next() else {
+        return Ok(None);
+    };
+    let mut composite = first;
+    for next in chain {
+        composite = composite.compose(&next)?;
+    }
+    Ok(Some(composite))
+}
+
+/// Quotient a step cospan's apex by the fingerprint groups of its target
+/// slice: right-boundary positions whose nodes carry equal state
+/// fingerprints get their apex vertices identified.
+fn glue_fingerprint_merges<S: Clone + Hash, T: Clone>(
+    graph: &MultiwayEvolutionGraph<S, T>,
+    target_slice: &catgraph_physics::multiway::BranchialGraph,
+    cospan: &Cospan<u32>,
+) -> Cospan<u32> {
+    let apex_count = cospan.middle().len();
+    let mut parent: Vec<usize> = (0..apex_count).collect();
+    fn find(parent: &mut [usize], mut i: usize) -> usize {
+        while parent[i] != i {
+            parent[i] = parent[parent[i]];
+            i = parent[i];
+        }
+        i
+    }
+
+    let mut first_apex_of_fp: HashMap<u64, usize> = HashMap::new();
+    for (pos, node_id) in target_slice.nodes.iter().enumerate() {
+        let Some(node) = graph.get_node(node_id) else {
+            continue;
+        };
+        let apex = cospan.right_to_middle()[pos];
+        if let Some(&seen) = first_apex_of_fp.get(&node.fingerprint) {
+            let (a, b) = (find(&mut parent, apex), find(&mut parent, seen));
+            if a != b {
+                parent[a] = b;
+            }
+        } else {
+            first_apex_of_fp.insert(node.fingerprint, apex);
+        }
+    }
+
+    // Rebuild with class representatives in first-seen order.
+    let mut apex_of_root: HashMap<usize, usize> = HashMap::new();
+    let remap = |parent: &mut [usize], old: usize, apex_of_root: &mut HashMap<usize, usize>| {
+        let root = find(parent, old);
+        let next = apex_of_root.len();
+        *apex_of_root.entry(root).or_insert(next)
+    };
+    let left: Vec<usize> = cospan
+        .left_to_middle()
+        .iter()
+        .map(|&m| remap(&mut parent, m, &mut apex_of_root))
+        .collect();
+    let right: Vec<usize> = cospan
+        .right_to_middle()
+        .iter()
+        .map(|&m| remap(&mut parent, m, &mut apex_of_root))
+        .collect();
+    let middle = vec![0u32; apex_of_root.len()];
+    Cospan::new(left, right, middle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::machines::multiway::StringRewriteSystem;
+
+    #[test]
+    fn step_corels_lift_every_step() {
+        let srs = StringRewriteSystem::new(vec![("A", "AB"), ("A", "BA")]);
+        let evolution = srs.run_multiway("A", 3, 32);
+        let corels = step_corels(&evolution).expect("step cospans are jointly surjective");
+        assert_eq!(corels.len(), multiway_step_cospans(&evolution).len());
+    }
+
+    #[test]
+    fn fork_step_groups_children_in_one_class() {
+        // "A" forks to "AB" | "BA": step 0 corelation has one class
+        // containing the parent and both children.
+        let srs = StringRewriteSystem::new(vec![("A", "AB"), ("A", "BA")]);
+        let evolution = srs.run_multiway("A", 1, 8);
+        let corels = step_corels(&evolution).expect("corels");
+        let first = &corels[0];
+
+        // Flat layout: domain (1 parent) | middle | codomain (2 children).
+        let dom_len = first.as_cospan().left_to_middle().len();
+        let mid_len = first.as_cospan().middle().len();
+        assert_eq!(dom_len, 1);
+        let child_a = dom_len + mid_len;
+        let child_b = dom_len + mid_len + 1;
+        assert!(
+            first.merges(child_a, child_b),
+            "fork children must share a class"
+        );
+        assert!(first.merges(0, child_a), "parent and child share the event");
+    }
+
+    #[test]
+    fn fingerprint_merge_glues_parent_branches() {
+        // Diamond: S forks to AB | BA, both rewrite to Z. The two Z nodes
+        // are distinct in the graph but fingerprint-equal — the step-1
+        // corelation must identify their parent branches.
+        let srs =
+            StringRewriteSystem::new(vec![("S", "AB"), ("S", "BA"), ("AB", "Z"), ("BA", "Z")]);
+        let evolution = srs.run_multiway("S", 2, 16);
+        let corels = step_corels(&evolution).expect("corels");
+        let merge_step = &corels[1];
+        assert_eq!(merge_step.as_cospan().left_to_middle().len(), 2);
+        assert!(
+            merge_step.merges(0, 1),
+            "fingerprint-merged parents must share a class"
+        );
+    }
+
+    #[test]
+    fn evolution_corel_composes_for_linear_trace() {
+        let mut graph: MultiwayEvolutionGraph<i32, ()> = MultiwayEvolutionGraph::new();
+        let root = graph.add_root(0);
+        let a = graph.add_sequential_step(root, 1, ());
+        let _ = graph.add_sequential_step(a, 2, ());
+
+        let corel = evolution_corel(&graph)
+            .expect("composition succeeds")
+            .expect("two steps present");
+        // Single track: one initial branch, one final branch, one class.
+        assert_eq!(corel.as_cospan().left_to_middle().len(), 1);
+        assert_eq!(corel.as_cospan().right_to_middle().len(), 1);
+        let dom_mid = 1 + corel.as_cospan().middle().len();
+        assert!(corel.merges(0, dom_mid), "root connects to final state");
+    }
+}

--- a/src/functor/mod.rs
+++ b/src/functor/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod adjunction;
 pub mod bifunctor;
+pub mod corel;
 pub mod fong_spivak;
 pub mod frobenius_preservation;
 pub mod interval_algebra;
@@ -32,6 +33,9 @@ pub use interval_algebra::{IntervalCospanAlgebra, multiway_step_cospans};
 pub use frobenius_preservation::{
     FrobeniusPreservationResult, StepFrobeniusCheck, verify_frobenius_preservation,
 };
+
+// Re-export the corelation surface (F&S 2018 Ex 6.64).
+pub use corel::{Corel, evolution_corel, step_corels};
 
 // Re-export adjunction types
 pub use adjunction::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,10 @@ pub use functor::{
     verify_frobenius_preservation,
 };
 
+// Corelation exports (F&S 2018 Ex 6.64)
+pub use functor::{Corel, evolution_corel, step_corels};
+pub use machines::hypergraph::MergesCorelExt;
+
 // Bifunctor / tensor product exports
 pub use functor::{
     IntervalTransform, TensorProduct, tensor_bimap, tensor_first, tensor_second,

--- a/src/machines/hypergraph/catgraph_bridge.rs
+++ b/src/machines/hypergraph/catgraph_bridge.rs
@@ -1,9 +1,176 @@
 //! Multiway cospan analysis for hypergraph evolution.
 //!
 //! Core types and extension trait re-exported from
-//! [`catgraph::hypergraph::multiway_cospan`].
+//! [`catgraph::hypergraph::multiway_cospan`], plus the local
+//! [`MergesCorelExt`] extension exposing the evolution's merge structure as
+//! a [`Corel`] (F&S 2018 Ex 6.64; issue #14).
+
+use std::collections::HashMap;
+
+use catgraph::corel::Corel;
+use catgraph::cospan::Cospan;
+use catgraph::errors::CatgraphError;
 
 pub use catgraph_physics::hypergraph::multiway_cospan::{
     CospanInvarianceResult, CospanMergeDetail, MultiwayCospan, MultiwayCospanExt,
     MultiwayCospanGraph,
 };
+
+/// Extension trait exposing an evolution's merge structure as a corelation
+/// over hypergraph vertex IDs.
+///
+/// Rewrite cospans keep vertex IDs global (legs are injective by ID), so
+/// all identification comes from **merge points**: states reached by
+/// different rewrite orderings whose fingerprints match. Vertices of merged
+/// states are aligned by sorted vertex-ID order — canonical for the
+/// fingerprint-equal states the upstream merge detector produces, but an
+/// approximation wherever a true isomorphism permutes IDs non-monotonically
+/// (recorded here rather than solving graph isomorphism).
+pub trait MergesCorelExt {
+    /// The merge partition over every vertex ID in the evolution, as a
+    /// corelation `x → x` where `x` is the sorted list of distinct vertex
+    /// IDs and two IDs share a class iff some chain of merge points
+    /// identifies them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatgraphError`] if the partition cospan fails corelation
+    /// validation (not expected — the construction is jointly surjective).
+    fn merges_corel(&self) -> Result<Corel<u32>, CatgraphError>;
+
+    /// The merge partition restricted to a caller-chosen boundary (e.g. the
+    /// initial graph's vertex IDs), in the given order.
+    ///
+    /// Two evolutions of the same initial graph under different rule
+    /// orderings restricted to the same boundary share domain and codomain,
+    /// so their partitions compare via [`Corel::refines`] /
+    /// [`Corel::coarsest_common_refinement`] — a candidate confluence test
+    /// stronger than the Wilson-loop check (which only compares composite
+    /// boundaries).
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::merges_corel`].
+    fn merges_corel_over(&self, boundary: &[u32]) -> Result<Corel<u32>, CatgraphError>;
+}
+
+impl MergesCorelExt for MultiwayCospanGraph {
+    fn merges_corel(&self) -> Result<Corel<u32>, CatgraphError> {
+        let mut all: Vec<u32> = self
+            .edges
+            .iter()
+            .flat_map(|e| e.cospan.middle().iter().copied())
+            .collect();
+        all.sort_unstable();
+        all.dedup();
+        self.merges_corel_over(&all)
+    }
+
+    fn merges_corel_over(&self, boundary: &[u32]) -> Result<Corel<u32>, CatgraphError> {
+        let classes = merge_classes(self);
+
+        // Class representative per boundary vertex (vertices not touched by
+        // any merge are their own class).
+        let mut apex_of_rep: HashMap<u32, usize> = HashMap::new();
+        let mut left = Vec::with_capacity(boundary.len());
+        let mut middle: Vec<u32> = Vec::new();
+        for &v in boundary {
+            let rep = classes.get(&v).copied().unwrap_or(v);
+            let next = middle.len();
+            let apex = *apex_of_rep.entry(rep).or_insert(next);
+            if apex == middle.len() {
+                middle.push(rep);
+            }
+            left.push(apex);
+        }
+
+        Corel::new(Cospan::new(left.clone(), left, middle))
+    }
+}
+
+/// Union-find over vertex IDs driven by merge-point alignment; returns the
+/// class representative (minimum vertex ID) for every vertex touched by a
+/// merge.
+fn merge_classes(graph: &MultiwayCospanGraph) -> HashMap<u32, u32> {
+    // A node's vertex set, from any incident cospan leg.
+    let mut vertices_of_node: HashMap<usize, Vec<u32>> = HashMap::new();
+    for edge in &graph.edges {
+        vertices_of_node.entry(edge.parent_id).or_insert_with(|| {
+            edge.cospan
+                .left_to_middle()
+                .iter()
+                .map(|&m| edge.cospan.middle()[m])
+                .collect()
+        });
+        vertices_of_node.entry(edge.child_id).or_insert_with(|| {
+            edge.cospan
+                .right_to_middle()
+                .iter()
+                .map(|&m| edge.cospan.middle()[m])
+                .collect()
+        });
+    }
+
+    fn find(parent: &mut HashMap<u32, u32>, v: u32) -> u32 {
+        let mut root = v;
+        while let Some(&p) = parent.get(&root) {
+            if p == root {
+                break;
+            }
+            root = p;
+        }
+        // Path compression.
+        let mut cur = v;
+        while let Some(&p) = parent.get(&cur) {
+            if p == root {
+                break;
+            }
+            parent.insert(cur, root);
+            cur = p;
+        }
+        root
+    }
+    fn union(parent: &mut HashMap<u32, u32>, a: u32, b: u32) {
+        let (ra, rb) = (find(parent, a), find(parent, b));
+        if ra != rb {
+            // Keep the minimum ID as representative.
+            let (lo, hi) = if ra < rb { (ra, rb) } else { (rb, ra) };
+            parent.insert(hi, lo);
+        }
+    }
+
+    let mut parent: HashMap<u32, u32> = HashMap::new();
+    for group in &graph.merge_points {
+        let Some((first, rest)) = group.split_first() else {
+            continue;
+        };
+        let Some(base) = vertices_of_node.get(first) else {
+            continue;
+        };
+        let mut base_sorted = base.clone();
+        base_sorted.sort_unstable();
+        for other in rest {
+            let Some(vs) = vertices_of_node.get(other) else {
+                continue;
+            };
+            if vs.len() != base_sorted.len() {
+                continue; // cannot align differently-sized states
+            }
+            let mut vs_sorted = vs.clone();
+            vs_sorted.sort_unstable();
+            for (&a, &b) in base_sorted.iter().zip(vs_sorted.iter()) {
+                union(&mut parent, a, b);
+            }
+        }
+    }
+
+    // Resolve every touched vertex to its representative.
+    let touched: Vec<u32> = parent.keys().copied().collect();
+    let mut out = HashMap::new();
+    for v in touched {
+        let rep = find(&mut parent, v);
+        out.insert(v, rep);
+        out.insert(rep, rep);
+    }
+    out
+}

--- a/src/machines/hypergraph/mod.rs
+++ b/src/machines/hypergraph/mod.rs
@@ -33,8 +33,8 @@ pub use catgraph_physics::hypergraph::{
     RewriteRule, RewriteSpan, WilsonLoop, plaquette_action, total_action,
 };
 
-// Local types (multiway cospan wrappers) and extension trait
+// Local types (multiway cospan wrappers) and extension traits
 pub use catgraph_bridge::{
-    CospanInvarianceResult, CospanMergeDetail, MultiwayCospan, MultiwayCospanExt,
+    CospanInvarianceResult, CospanMergeDetail, MergesCorelExt, MultiwayCospan, MultiwayCospanExt,
     MultiwayCospanGraph,
 };

--- a/tests/hypergraph_rewriting.rs
+++ b/tests/hypergraph_rewriting.rs
@@ -394,3 +394,139 @@ fn multiway_evolution_with_gauge_analysis_pipeline() {
     assert!(stats.max_step >= 1);
     assert!(!stats.rule_applications.is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Merge partition as a corelation (F&S 2018 Ex 6.64) — issue #14
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merges_corel_builds_over_all_vertices() {
+    use irreducible::machines::hypergraph::{MergesCorelExt, MultiwayCospanExt};
+
+    let rule = RewriteRule::wolfram_a_to_bb();
+    let graph = Hypergraph::from_edges(vec![vec![0, 1, 2]]);
+    let evolution = HypergraphEvolution::run_multiway(&graph, &[rule], 3, 50);
+
+    let cospan_graph = evolution.to_multiway_cospan_graph();
+    let corel = cospan_graph.merges_corel().expect("corelation builds");
+    assert!(
+        !corel.equivalence_classes().is_empty(),
+        "evolution has vertices, so the partition has classes"
+    );
+}
+
+#[test]
+fn merge_partition_consistent_with_merge_points() {
+    use irreducible::machines::hypergraph::{MergesCorelExt, MultiwayCospanExt};
+
+    // Two independent match sites: different application orders reach the
+    // same final state — fingerprint merges appear.
+    let rule = RewriteRule::wolfram_a_to_bb();
+    let graph = Hypergraph::from_edges(vec![vec![0, 1, 2], vec![3, 4, 5]]);
+    let evolution = HypergraphEvolution::run_multiway(&graph, &[rule], 3, 100);
+
+    let cospan_graph = evolution.to_multiway_cospan_graph();
+    let corel = cospan_graph.merges_corel().expect("corelation builds");
+    assert!(
+        !cospan_graph.merge_points.is_empty(),
+        "two independent sites must produce fingerprint merges"
+    );
+
+    // Consistency contract: for every merge group, the sorted vertex-ID
+    // alignment of any two member states must land in one equivalence
+    // class of the corelation. (wolfram_a_to_bb creates no fresh vertices,
+    // so aligned IDs may be equal — merges() must hold either way.)
+    let boundary: Vec<u32> = {
+        let mut all: Vec<u32> = cospan_graph
+            .edges
+            .iter()
+            .flat_map(|e| e.cospan.middle().iter().copied())
+            .collect();
+        all.sort_unstable();
+        all.dedup();
+        all
+    };
+    let flat = |v: u32| -> usize {
+        boundary
+            .iter()
+            .position(|&b| b == v)
+            .expect("merged vertex appears in the evolution")
+    };
+
+    let vertices_of = |node: usize| -> Option<Vec<u32>> {
+        cospan_graph.edges.iter().find_map(|e| {
+            if e.child_id == node {
+                Some(
+                    e.cospan
+                        .right_to_middle()
+                        .iter()
+                        .map(|&m| e.cospan.middle()[m])
+                        .collect(),
+                )
+            } else if e.parent_id == node {
+                Some(
+                    e.cospan
+                        .left_to_middle()
+                        .iter()
+                        .map(|&m| e.cospan.middle()[m])
+                        .collect(),
+                )
+            } else {
+                None
+            }
+        })
+    };
+
+    for group in &cospan_graph.merge_points {
+        let (first, rest) = group.split_first().expect("groups are non-empty");
+        let mut base = vertices_of(*first).expect("node has vertices");
+        base.sort_unstable();
+        for other in rest {
+            let mut vs = vertices_of(*other).expect("node has vertices");
+            vs.sort_unstable();
+            assert_eq!(vs.len(), base.len(), "merged states have equal size");
+            for (&a, &b) in base.iter().zip(vs.iter()) {
+                assert!(
+                    corel.merges(flat(a), flat(b)),
+                    "aligned vertices {a} and {b} must share a class"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn rule_ordering_confluence_via_coarsest_common_refinement() {
+    use irreducible::machines::hypergraph::{MergesCorelExt, MultiwayCospanExt};
+
+    // Same initial graph, two rule orderings. Restricting both merge
+    // partitions to the initial vertex IDs makes them comparable.
+    let r1 = RewriteRule::wolfram_a_to_bb();
+    let r2 = RewriteRule::edge_split();
+    let graph = Hypergraph::from_edges(vec![vec![0, 1, 2]]);
+    let initial_vertices: Vec<u32> = vec![0, 1, 2];
+
+    let evo_a = HypergraphEvolution::run_multiway(&graph, &[r1.clone(), r2.clone()], 3, 50);
+    let evo_b = HypergraphEvolution::run_multiway(&graph, &[r2, r1], 3, 50);
+
+    let corel_a = evo_a
+        .to_multiway_cospan_graph()
+        .merges_corel_over(&initial_vertices)
+        .expect("corelation A");
+    let corel_b = evo_b
+        .to_multiway_cospan_graph()
+        .merges_corel_over(&initial_vertices)
+        .expect("corelation B");
+
+    // The lattice law: the coarsest common refinement refines both inputs.
+    let ccr = corel_a
+        .coarsest_common_refinement(&corel_b)
+        .expect("shared boundary -> comparable");
+    assert!(ccr.refines(&corel_a).expect("same boundary"));
+    assert!(ccr.refines(&corel_b).expect("same boundary"));
+
+    // Rule order permutes exploration, not identification: the partitions
+    // over the shared initial vertices must agree (the confluence signal).
+    assert!(corel_a.refines(&corel_b).expect("same boundary"));
+    assert!(corel_b.refines(&corel_a).expect("same boundary"));
+}

--- a/tests/multiway_evolution.rs
+++ b/tests/multiway_evolution.rs
@@ -326,3 +326,91 @@ fn srs_empty_rules_no_evolution() {
     assert!(evolution.find_fork_points().is_empty());
     assert!(evolution.find_merge_points().is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Corelation merge partitions (F&S 2018 Ex 6.64) — issue #14
+// ---------------------------------------------------------------------------
+
+#[test]
+fn confluent_srs_diamond_merges_in_step_corel() {
+    use irreducible::step_corels;
+
+    // Diamond: S forks to AB | BA, both rewrite to Z — a genuine merge.
+    let srs = StringRewriteSystem::new(vec![("S", "AB"), ("S", "BA"), ("AB", "Z"), ("BA", "Z")]);
+    let evolution = srs.run_multiway("S", 2, 16);
+
+    // Fixture sanity: both step-2 nodes carry the same fingerprint ("Z"
+    // along both paths). The multiway explorer keeps them as distinct
+    // nodes, so the merge exists only at the fingerprint level — which is
+    // exactly what the corelation records.
+    let final_slice = &extract_branchial_foliation(&evolution)[2];
+    let fingerprints: Vec<u64> = final_slice
+        .nodes
+        .iter()
+        .filter_map(|id| evolution.get_node(id).map(|n| n.fingerprint))
+        .collect();
+    assert_eq!(fingerprints.len(), 2, "diamond reaches two step-2 nodes");
+    assert_eq!(
+        fingerprints[0], fingerprints[1],
+        "diamond fixture must reconverge"
+    );
+
+    let corels = step_corels(&evolution).expect("step corels");
+    // Step 1: two parent branches (AB, BA) converge on Z — one class.
+    let merge_step = &corels[1];
+    assert_eq!(merge_step.as_cospan().left_to_middle().len(), 2);
+    assert!(
+        merge_step.merges(0, 1),
+        "merging parents must share an equivalence class"
+    );
+}
+
+#[test]
+fn non_confluent_srs_fragment_keeps_branches_separate() {
+    use irreducible::step_corels;
+
+    // Fork with distinct continuations, no reconvergence.
+    let srs = StringRewriteSystem::new(vec![("S", "AB"), ("S", "BA"), ("AB", "AC"), ("BA", "BC")]);
+    let evolution = srs.run_multiway("S", 2, 16);
+
+    // Fixture sanity: the two step-2 states are distinct — no merge.
+    let final_slice = &extract_branchial_foliation(&evolution)[2];
+    let fingerprints: Vec<u64> = final_slice
+        .nodes
+        .iter()
+        .filter_map(|id| evolution.get_node(id).map(|n| n.fingerprint))
+        .collect();
+    assert_eq!(fingerprints.len(), 2);
+    assert_ne!(fingerprints[0], fingerprints[1], "fixture must not merge");
+
+    let corels = step_corels(&evolution).expect("step corels");
+    // Step 1: two parent branches evolve independently — separate classes.
+    let step = &corels[1];
+    assert_eq!(step.as_cospan().left_to_middle().len(), 2);
+    assert!(
+        !step.merges(0, 1),
+        "independent branches must stay in distinct classes"
+    );
+}
+
+#[test]
+fn evolution_corel_composes_across_diamond() {
+    use irreducible::evolution_corel;
+
+    let srs = StringRewriteSystem::new(vec![("S", "AB"), ("S", "BA"), ("AB", "Z"), ("BA", "Z")]);
+    let evolution = srs.run_multiway("S", 2, 16);
+    let corel = evolution_corel(&evolution)
+        .expect("composition succeeds")
+        .expect("evolution has steps");
+
+    // One root in; two final positions (the distinct Z nodes) glued into
+    // one class, causally connected to the root.
+    assert_eq!(corel.as_cospan().left_to_middle().len(), 1);
+    assert_eq!(corel.as_cospan().right_to_middle().len(), 2);
+    let dom_mid = 1 + corel.as_cospan().middle().len();
+    assert!(
+        corel.merges(dom_mid, dom_mid + 1),
+        "the two final positions are one merged state"
+    );
+    assert!(corel.merges(0, dom_mid), "root connects to the final state");
+}


### PR DESCRIPTION
Closes #14.

## Key discovery during implementation

The multiway explorer keeps same-state nodes reached along different paths as **distinct graph nodes** — merge events exist only at the fingerprint level, never as shared-child graph edges. So the raw step-cospan chain (#11) is merge-blind by construction, and the corelation layer is exactly the structure that records fingerprint identification.

## What ships

- **`functor::corel`** — `Corel` re-exported (the issue's "new corel.rs" option) plus:
  - `step_corels`: lifts the step-cospan chain to corelations, **gluing fingerprint-coincident target states** (apex quotient). A merge is one class holding both parent branches; a fork one class holding both children. The raw chain stays untouched — it is #12's Frobenius event-census substrate and must reflect graph edges only.
  - `evolution_corel`: pushout-composes the chain into one whole-evolution partition.
- **`MergesCorelExt` on `MultiwayCospanGraph`** — `merges_corel[_over]`: the merge partition over hypergraph **vertex IDs** (the issue's acceptance item 3). Merge-point states are aligned by sorted vertex-ID order — canonical for fingerprint-equal states, a documented approximation wherever an isomorphism permutes IDs non-monotonically.
- **Confluence comparison** (acceptance item 4): restricting two rule-ordering runs to the shared initial vertex IDs gives comparable partitions; the test asserts the `coarsest_common_refinement` lattice law (ccr refines both inputs) and that rule order does not change the identification of initial vertices.

## Tests (acceptance item 5)

- Confluent SRS diamond (`S→AB|BA`, both `→Z`): fingerprint sanity + the merging parents share a class in the step corelation; the composed evolution corel identifies the two final positions.
- Non-confluent fragment (distinct continuations): branches stay in separate classes.
- Hypergraph merge-point consistency: for every merge group, every aligned vertex pair lands in one equivalence class.
- `MultiwayCospanGraph` corelation over all vertices + the cross-ordering `coarsest_common_refinement` comparison.

Gates: 393 default / 420 feature-leg tests, clippy `-D warnings` both legs, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)